### PR TITLE
Added an "icon tint" field to status creator

### DIFF
--- a/module/sheets/status-creator.mjs
+++ b/module/sheets/status-creator.mjs
@@ -44,6 +44,7 @@ export class StatusCreator extends HandlebarsApplicationMixin(ApplicationV2) {
       `status_${this.number}_img`,
       `status_${this.number}_bgColor`,
       `status_${this.number}_textColor`,
+      `status_${this.number}_iconTint`,
     ];
     if (advanced) {
       this.hiddenAbilities = [...StatusCreator.hiddenAbilities];
@@ -83,6 +84,7 @@ export class StatusCreator extends HandlebarsApplicationMixin(ApplicationV2) {
       status_img: storedData[this.storageKeys[0]] || "icons/svg/stoned.svg",
       status_bgColor: storedData[this.storageKeys[1]],
       status_textColor: storedData[this.storageKeys[2]],
+      status_iconTint: storedData[this.storageKeys[3]],
     };
 
     context.returnedData = context.storedData.img;
@@ -162,6 +164,7 @@ export class StatusCreator extends HandlebarsApplicationMixin(ApplicationV2) {
     const img = html.img.value;
     const bgColor = html.bgColor.value;
     const textColor = html.textColor.value;
+    const iconTint = html.iconTint.value;
 
     const effects = abilities
       .map((ability) => {
@@ -236,7 +239,7 @@ export class StatusCreator extends HandlebarsApplicationMixin(ApplicationV2) {
           },
           description: description || "",
           origin: "",
-          tint: bgColor,
+          tint: iconTint,
           transfer: true,
           statuses: new Set(),
           flags: {},
@@ -272,6 +275,7 @@ export class StatusCreator extends HandlebarsApplicationMixin(ApplicationV2) {
       [this.storageKeys[0]]: img,
       [this.storageKeys[1]]: bgColor,
       [this.storageKeys[2]]: textColor,
+      [this.storageKeys[3]]: iconTint,
     };
 
     await erps.utils.storeLocal(storageObject);

--- a/templates/macros/status-creator.hbs
+++ b/templates/macros/status-creator.hbs
@@ -19,12 +19,16 @@
     <input class="base-form__hidden-input" type="hidden" name="img" value="{{ifThen storedData.status_img storedData.status_img "icons/svg/stoned.svg"}}">
   </div>
   <div class="base-form__group">
-    <label class="base-form__label" for="bgColor">Background Color/Tint:</label>
+    <label class="base-form__label" for="bgColor">Background Color:</label>
     <input class="base-form__color-input" type="color" id="bgColor" name="bgColor" value="{{ifThen storedData.status_bgColor storedData.status_bgColor "#7B4874"}}">
   </div>
   <div class="base-form__group">
     <label class="base-form__label" for="textColor">Text Color:</label>
     <input class="base-form__color-input" type="color" id="textColor" name="textColor" value="{{ifThen storedData.status_textColor storedData.status_textColor "#ffffff"}}">
+  </div>
+  <div class="base-form__group">
+    <label class=""base-form__label for="iconTint">Icon Tint:</label>
+    <input class="base-form__color-input" type="color" id="iconTint" name="iconTint" value="{{ifThen storedData.status_iconTint storedData.status_iconTint "#ffffff"}}">
   </div>
   <div class="base-form__header">Effects</div>
   {{#each abilities}}


### PR DESCRIPTION
This will allow game masters to independently set the icon tint from the background color: preventing niche bugs that could occur under the other method due to want from my users to be able to use icon types other than SVG.