### PR TITLE
jsconfig.json update to modern standards

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "lib": ["ES2022", "DOM"],
     "module": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "strict": false,
     "noImplicitAny": false,
@@ -13,7 +13,6 @@
     "declaration": false,
     "allowJs": true,
     "skipLibCheck": true,
-    "baseUrl": ".",
     "types": [],
     "typeRoots": [
       "./node_modules/@types"


### PR DESCRIPTION
The latest vscode informed me that node moduleResolution was being discontinued and because the project already follows the stricter "bundler" methodology I've simply changed the file to support it.