### PR TITLE
fix: Remove aggressive DOM cleanup on visibilitychange that broke sheets

### DIFF
--- a/module/eventide-rp-system.mjs
+++ b/module/eventide-rp-system.mjs
@@ -666,31 +666,30 @@ async function rollItemMacro(itemUuid) {
 /**
  * Clean up system resources when the world is being shut down
  * This helps prevent memory leaks and ensures proper cleanup
+ * 
+ * NOTE: We do NOT perform cleanup on:
+ * - visibilitychange (alt-tab): Would destroy active DOM elements
+ * - pause: Too aggressive, could break active sheets
+ * 
+ * Cleanup only happens on:
+ * - beforeunload: Browser/page close (proper shutdown)
+ * - hot reload: Development module reload
  */
 Hooks.on("paused", (paused) => {
-  // If the game is being paused (which can indicate shutdown), perform cleanup
+  // Only log, don't perform aggressive cleanup on pause
+  // Pause can happen during normal gameplay (e.g., combat pause)
   if (paused && game.user.isGM) {
-    Logger.info("Performing system cleanup on pause", null, "SYSTEM_CLEANUP");
-    try {
-      performSystemCleanup();
-    } catch (error) {
-      Logger.error(
-        "Failed to perform cleanup on pause",
-        error,
-        "SYSTEM_CLEANUP",
-      );
-    }
+    Logger.debug("Game paused", null, "SYSTEM_CLEANUP");
   }
 });
 
-// Also clean up on any system disable/reload events if available
+// Log when system applications close (for debugging only)
 if (typeof Hooks.on === "function") {
-  // Listen for any potential system disable events
   Hooks.on("closeApplication", (app) => {
-    // If this is a system-critical application closing, consider cleanup
+    // Log system application closures for debugging purposes only
     if (app.constructor.name.includes("EventideRpSystem")) {
-      Logger.info(
-        "System application closing, checking for cleanup needs",
+      Logger.debug(
+        "System application closing",
         { appName: app.constructor.name },
         "SYSTEM_CLEANUP",
       );

--- a/module/utils/system-cleanup.mjs
+++ b/module/utils/system-cleanup.mjs
@@ -132,7 +132,16 @@ function clearAllSystemIntervals() {
 }
 
 /**
- * Clean up orphaned DOM elements that might hold references
+ * Clean up orphaned GM control status elements
+ * 
+ * NOTE: This function intentionally does NOT clean up:
+ * - Theme attributes on active sheets (would break active UI)
+ * - ERPS DOM elements via cloneNode (would destroy event listeners)
+ * 
+ * These operations were removed because they break Foundry V2's ApplicationV2
+ * framework, which maintains internal references to DOM elements. Cloning
+ * elements destroys these references and causes sheets to fail to open.
+ * 
  * @private
  */
 function cleanupOrphanedElements() {
@@ -144,71 +153,6 @@ function cleanupOrphanedElements() {
         el.remove();
       } catch (error) {
         safeLog("warn", "Failed to remove GM status element", error);
-      }
-    });
-
-    // Only clean up theme attributes if we're doing a full system cleanup
-    // This prevents theme loss during alt-tab
-    if (document.visibilityState === "hidden") {
-      safeLog("debug", "Skipping theme cleanup during visibility change");
-      return;
-    }
-
-    // Remove any orphaned theme-related elements and attributes
-    /**
-     * Clean up all theme-related attributes and elements to prevent memory leaks
-     * and ensure clean state on system reload. This includes:
-     * - Global theme attributes (data-theme)
-     * - Component-specific theme attributes (data-bg-theme, data-tab-theme, etc.)
-     * - Eventide-specific theme attributes (data-eventide-theme)
-     *
-     * This cleanup is essential for preventing theme-related issues during
-     * system reloads and ensuring proper theme application on restart.
-     */
-    const themeElements = document.querySelectorAll(
-      "[data-eventide-theme], [data-theme], [data-bg-theme], [data-tab-theme], [data-name-theme], [data-header-theme], [data-table-theme], [data-section-theme], [data-toggle-theme], [data-biography-theme], [data-input-theme], [data-select-theme], [data-button-theme], [data-color-theme], [data-textarea-theme], [data-items-theme]",
-    );
-    themeElements.forEach((el) => {
-      try {
-        // Remove all theme-related attributes
-        el.removeAttribute("data-eventide-theme");
-        el.removeAttribute("data-theme");
-        el.removeAttribute("data-bg-theme");
-        el.removeAttribute("data-tab-theme");
-        el.removeAttribute("data-name-theme");
-        el.removeAttribute("data-header-theme");
-        el.removeAttribute("data-table-theme");
-        el.removeAttribute("data-section-theme");
-        el.removeAttribute("data-toggle-theme");
-        el.removeAttribute("data-biography-theme");
-        el.removeAttribute("data-input-theme");
-        el.removeAttribute("data-select-theme");
-        el.removeAttribute("data-button-theme");
-        el.removeAttribute("data-color-theme");
-        el.removeAttribute("data-textarea-theme");
-        el.removeAttribute("data-items-theme");
-      } catch (error) {
-        safeLog("warn", "Failed to clean theme attributes", error);
-      }
-    });
-
-    /**
-     * Clean up ERPS-specific elements including theme-related classes
-     * This ensures all custom elements and their event listeners are properly
-     * cleaned up during system shutdown or reload.
-     */
-    const erpsElements = document.querySelectorAll(
-      "[class*='erps-'], [data-erps], .eventide-sheet",
-    );
-    erpsElements.forEach((el) => {
-      try {
-        // Clone and replace to remove event listeners
-        const clone = el.cloneNode(true);
-        if (el.parentNode) {
-          el.parentNode.replaceChild(clone, el);
-        }
-      } catch (error) {
-        safeLog("warn", "Failed to clean ERPS element", error);
       }
     });
 
@@ -234,17 +178,11 @@ export function initializeCleanupHooks() {
 
   // Clean up when the world is being shut down
   Hooks.on("ready", () => {
-    // Set up cleanup on page unload
+    // Set up cleanup on page unload only
+    // NOTE: We do NOT clean up on visibilitychange (alt-tab) because that would
+    // destroy active DOM elements and break Foundry V2's ApplicationV2 framework.
     window.addEventListener("beforeunload", () => {
       performSystemCleanup();
-    });
-
-    // Set up cleanup on page visibility change (when tab becomes hidden)
-    document.addEventListener("visibilitychange", () => {
-      if (document.hidden) {
-        safeLog("debug", "Page hidden, performing cleanup");
-        performSystemCleanup();
-      }
     });
   });
 


### PR DESCRIPTION
## Problem

Since upgrading to Foundry V14, users experienced intermittent issues:
- **200 (OK) errors in console for images** - Images would load successfully but appear broken
- **Sheets failing to open** - Double-clicking a character would not open the sheet
- **Issues resolved by reloading** - But sometimes would occur back-to-back or across multiple reloads

## Root Cause

The `visibilitychange` event handler in `module/utils/system-cleanup.mjs` was triggering `performSystemCleanup()` every time the user alt-tabbed away from Foundry (or switched browser tabs).

This cleanup performed three destructive operations:
1. **Stripped all theme attributes** from every DOM element
2. **Cloned and replaced all ERPS elements** via `cloneNode(true)` - destroying ALL event listeners
3. **Cleared theme manager instances**

## Why This Broke Foundry V2

Foundry V2's `ApplicationV2` framework maintains **internal references to DOM elements**. When `cloneNode(true)` replaces elements:
1. Foundry's internal references point to **orphaned DOM elements**
2. New elements have **no event listeners** attached
3. Sheets fail to open because the framework can't interact with the DOM
4. Images load (200 OK) but UI bindings are broken

## Solution

### `module/utils/system-cleanup.mjs`
- Removed the `visibilitychange` cleanup handler
- Removed the DOM-cloning logic from `cleanupOrphanedElements()`
- Removed the theme attribute stripping
- Added documentation explaining why these operations are unsafe for Foundry V2

### `module/eventide-rp-system.mjs`
- Changed the `paused` hook from performing cleanup to just logging
- Added comments explaining when cleanup should/shouldn't happen

### Cleanup Now Only Happens On
- `beforeunload`: Browser/page close
- Hot reload: Development module reload

## Files Changed
- `module/utils/system-cleanup.mjs`
- `module/eventide-rp-system.mjs`
