### PR TITLE
Fix: Gear tab subtabs not working due to mixin method override conflict

### DIFF
--- a/module/ui/mixins/actor-sheet-feature-tabs.mjs
+++ b/module/ui/mixins/actor-sheet-feature-tabs.mjs
@@ -19,27 +19,30 @@ export const ActorSheetFeatureTabsMixin = createTabManagementMixin({
   contentDataAttr: "data-feature-content",
   defaultTab: "active",
   stateProperty: "_currentFeatureTab",
+  initMethodName: "_initFeatureTabs",
+  cleanupMethodName: "_cleanupFeatureTabs",
 });
 
 // Extend the mixin to provide specific initialization and cleanup methods
+// that can be called from the actor sheet's _onRender
 export const ActorSheetFeatureTabsMixinWithInit = (BaseClass) => {
   const MixedClass = ActorSheetFeatureTabsMixin(BaseClass);
   
   return class extends MixedClass {
     /**
-     * Initialize feature tab management
-     * @protected
-     */
+      * Initialize feature tab management
+      * @protected
+      */
     _initFeatureTabManagement() {
-      this._initTabManagement();
+      this._initFeatureTabs();
     }
 
     /**
-     * Clean up feature tab management
-     * @protected
-     */
+      * Clean up feature tab management
+      * @protected
+      */
     _cleanupFeatureTabManagement() {
-      this._cleanupTabManagement();
+      this._cleanupFeatureTabs();
     }
   };
 };

--- a/module/ui/mixins/actor-sheet-gear-tabs.mjs
+++ b/module/ui/mixins/actor-sheet-gear-tabs.mjs
@@ -19,27 +19,30 @@ export const ActorSheetGearTabsMixin = createTabManagementMixin({
   contentDataAttr: "data-gear-content",
   defaultTab: "equipped",
   stateProperty: "_currentGearTab",
+  initMethodName: "_initGearTabs",
+  cleanupMethodName: "_cleanupGearTabs",
 });
 
 // Extend the mixin to provide specific initialization and cleanup methods
+// that can be called from the actor sheet's _onRender
 export const ActorSheetGearTabsMixinWithInit = (BaseClass) => {
   const MixedClass = ActorSheetGearTabsMixin(BaseClass);
   
   return class extends MixedClass {
     /**
-     * Initialize gear tab management
-     * @protected
-     */
+      * Initialize gear tab management
+      * @protected
+      */
     _initGearTabManagement() {
-      this._initTabManagement();
+      this._initGearTabs();
     }
 
     /**
-     * Clean up gear tab management
-     * @protected
-     */
+      * Clean up gear tab management
+      * @protected
+      */
     _cleanupGearTabManagement() {
-      this._cleanupTabManagement();
+      this._cleanupGearTabs();
     }
   };
 };

--- a/module/ui/mixins/actor-sheet-tab-management.mjs
+++ b/module/ui/mixins/actor-sheet-tab-management.mjs
@@ -13,10 +13,16 @@
  * @param {string} config.contentDataAttr - Data attribute for tab contents (e.g., "data-feature-content")
  * @param {string} config.defaultTab - Default tab to activate (e.g., "active" or "equipped")
  * @param {string} config.stateProperty - Property name for storing current tab state (e.g., "_currentFeatureTab")
+ * @param {string} config.initMethodName - Unique method name for initialization (e.g., "_initGearTabs")
+ * @param {string} config.cleanupMethodName - Unique method name for cleanup (e.g., "_cleanupGearTabs")
  * @returns {class} Extended class with tab management functionality
  */
-export const createTabManagementMixin = (config) => (BaseClass) =>
-  class extends BaseClass {
+export const createTabManagementMixin = (config) => (BaseClass) => {
+  // Extract method names from config
+  const initMethodName = config.initMethodName || "_initTabManagement";
+  const cleanupMethodName = config.cleanupMethodName || "_cleanupTabManagement";
+
+  return class extends BaseClass {
     /**
      * Initialize tab functionality with state preservation
      * @private
@@ -64,9 +70,14 @@ export const createTabManagementMixin = (config) => (BaseClass) =>
           // Store the selected tab
           this[config.stateProperty] = targetTab;
 
+          // Query fresh DOM references for buttons and contents
+          // (originals may be stale after re-renders)
+          const freshButtons = this.element.querySelectorAll(config.buttonSelector);
+          const freshContents = this.element.querySelectorAll(config.contentSelector);
+
           // Remove active class from all buttons and contents
-          newTabButtons.forEach((btn) => btn.classList.remove("active"));
-          tabContents.forEach((content) => content.classList.remove("active"));
+          freshButtons.forEach((btn) => btn.classList.remove("active"));
+          freshContents.forEach((content) => content.classList.remove("active"));
 
           // Add active class to clicked button and corresponding content
           button.classList.add("active");
@@ -134,7 +145,7 @@ export const createTabManagementMixin = (config) => (BaseClass) =>
      * Call this from your _onRender method
      * @protected
      */
-    _initTabManagement() {
+    [initMethodName]() {
       this.#initTabs();
     }
 
@@ -143,7 +154,8 @@ export const createTabManagementMixin = (config) => (BaseClass) =>
      * Call this from your _preClose method
      * @protected
      */
-    _cleanupTabManagement() {
+    [cleanupMethodName]() {
       this.#cleanupTabState();
     }
   };
+};

--- a/templates/actor/features.hbs
+++ b/templates/actor/features.hbs
@@ -3,17 +3,17 @@
 
   {{! Features Tab Navigation }}
   <div class="feature-tab-nav">
-    <button class="feature-tab-button feature-tab-button--active active" data-feature-tab="active">
+    <button type="button" class="feature-tab-button feature-tab-button--active active" data-feature-tab="active">
       <i class='fa-solid fa-power-off'></i>
       {{localize "EVENTIDE_RP_SYSTEM.Forms.Sections.ActiveFeatures"}}
       <span class="feature-count">{{activeFeatureCount}}</span>
     </button>
-    <button class="feature-tab-button feature-tab-button--inactive" data-feature-tab="inactive">
+    <button type="button" class="feature-tab-button feature-tab-button--inactive" data-feature-tab="inactive">
       <i class='fa-solid fa-ban'></i>
       {{localize "EVENTIDE_RP_SYSTEM.Forms.Sections.InactiveFeatures"}}
       <span class="feature-count">{{inactiveFeatureCount}}</span>
     </button>
-    <button class="feature-tab-button feature-tab-button--all" data-feature-tab="all">
+    <button type="button" class="feature-tab-button feature-tab-button--all" data-feature-tab="all">
       <i class='fa-solid fa-list'></i>
       {{localize "EVENTIDE_RP_SYSTEM.Forms.Sections.AllFeatures"}}
       <span class="feature-count">{{featureCount}}</span>

--- a/templates/actor/gear.hbs
+++ b/templates/actor/gear.hbs
@@ -3,12 +3,12 @@
 
   {{! Gear Tab Navigation }}
   <div class="gear-tab-nav">
-    <button class="gear-tab-button gear-tab-button--equipped active" data-gear-tab="equipped">
+    <button type="button" class="gear-tab-button gear-tab-button--equipped active" data-gear-tab="equipped">
       <i class='fa-solid fa-helmet-battle'></i>
       {{localize "EVENTIDE_RP_SYSTEM.Forms.Sections.ActiveGear"}}
       <span class="gear-count">{{equippedGear.length}}</span>
     </button>
-    <button class="gear-tab-button gear-tab-button--unequipped" data-gear-tab="unequipped">
+    <button type="button" class="gear-tab-button gear-tab-button--unequipped" data-gear-tab="unequipped">
       <i class='fa-solid fa-box'></i>
       {{localize "EVENTIDE_RP_SYSTEM.Forms.Sections.UnequippedGear"}}
       <span class="gear-count">{{unequippedGear.length}}</span>


### PR DESCRIPTION
## Summary
Fixes an issue where the gear subtabs (Equipped/Unequipped) on character sheets were non-functional, while the feature subtabs worked correctly.

## Root Cause
The `ActorSheetGearTabsMixin` and `ActorSheetFeatureTabsMixin` both defined a method `_initTabManagement()` through the generic `createTabManagementMixin` factory. Due to mixin composition order, the feature mixin's method completely overrode the gear mixin's method.

When `_initGearTabManagement()` called `this._initTabManagement()`, it executed the feature tab initialization code (searching for `.feature-tab-button` elements) instead of the gear tab code. Since no feature buttons existed in the gear tab, the initialization did nothing — no click handlers were bound.

## Solution
Modified `createTabManagementMixin` to accept `initMethodName` and `cleanupMethodName` config parameters, using computed property names to create uniquely named methods:
- Gear tabs: `_initGearTabs()`, `_cleanupGearTabs()`
- Feature tabs: `_initFeatureTabs()`, `_cleanupFeatureTabs()`

## Changes
- **actor-sheet-tab-management.mjs**: Added `initMethodName`/`cleanupMethodName` config options with computed property names
- **actor-sheet-gear-tabs.mjs**: Added unique method names to config
- **actor-sheet-feature-tabs.mjs**: Added unique method names to config
- **gear.hbs**: Added `type="button"` to subtab buttons (preventive)
- **features.hbs**: Added `type="button"` to subtab buttons (preventive)

## Testing
- ✅ Build passes (`npm run build`)
- ✅ Validation passes (`npm run validate`)
- ✅ Gear subtabs now work correctly
- ✅ Feature subtabs continue to work correctly