### PR TITLE
fix: prevent sheet image hover glow from clipping at edges

### DIFF
--- a/css/eventide-rp-system.css
+++ b/css/eventide-rp-system.css
@@ -970,7 +970,7 @@
 }
 .eventide-actor__profile-img:hover, .eventide-profile-image--actor:hover, .eventide-profile-image:hover, .eventide-sheet .eventide-actor__header .eventide-sheet__profile-img:hover {
   border: 3px inset rgba(255, 255, 255, 0.9);
-  transform: scale(1.05);
+  transform: scale(1.03);
   box-shadow: 0 0 15px rgba(255, 255, 255, 0.8), inset 1px 1px 7.95px rgba(0, 0, 0, 0.24), inset -1px -1px 4.05px rgba(255, 255, 255, 0.16);
 }
 .eventide-actor__profile-img--disabled, .eventide-profile-image--disabled {
@@ -1377,6 +1377,7 @@ label,
   flex-shrink: 0;
   position: relative;
   z-index: 2;
+  margin: 0.25rem;
 }
 .eventide-sheet .eventide-sheet__header--item .eventide-sheet__header-fields {
   flex: 1;
@@ -1394,6 +1395,9 @@ label,
   padding: 0.2rem;
   margin-bottom: 0.5rem;
   position: relative;
+}
+.eventide-sheet .eventide-sheet__header--actor .flexcol.grid-span-2 {
+  padding: 0.25rem;
 }
 .eventide-sheet .eventide-sheet__header--actor::before {
   content: "";
@@ -4062,6 +4066,7 @@ body.erps-image-zoom-active {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 .erps-data-table--compact .erps-data-table__header-cell,

--- a/css/eventide-rp-system.css
+++ b/css/eventide-rp-system.css
@@ -970,7 +970,7 @@
 }
 .eventide-actor__profile-img:hover, .eventide-profile-image--actor:hover, .eventide-profile-image:hover, .eventide-sheet .eventide-actor__header .eventide-sheet__profile-img:hover {
   border: 3px inset rgba(255, 255, 255, 0.9);
-  transform: scale(1.03);
+  transform: scale(1.02);
   box-shadow: 0 0 15px rgba(255, 255, 255, 0.8), inset 1px 1px 7.95px rgba(0, 0, 0, 0.24), inset -1px -1px 4.05px rgba(255, 255, 255, 0.16);
 }
 .eventide-actor__profile-img--disabled, .eventide-profile-image--disabled {

--- a/src/scss/components/sheet/_erps-profile-images.scss
+++ b/src/scss/components/sheet/_erps-profile-images.scss
@@ -30,7 +30,6 @@ $profile-inner-shadow-opacity-hover: 0.2;
 
 // Transitions
 $profile-transition: all tokens.$sheet-transition-medium;
-$profile-hover-scale: 1.03;
 
 // Opacity values
 $profile-disabled-opacity: tokens.$sheet-opacity-disabled;
@@ -146,7 +145,7 @@ $profile-disabled-overlay-opacity: 0.6;
 
   &:hover {
     border: $profile-border-width inset rgb(255 255 255 / 90%);
-    transform: scale($profile-hover-scale);
+    transform: scale(tokens.$sheet-profile-hover-scale);
 
     @include profile-shadow-hover;
   }

--- a/src/scss/components/sheet/_erps-profile-images.scss
+++ b/src/scss/components/sheet/_erps-profile-images.scss
@@ -30,7 +30,7 @@ $profile-inner-shadow-opacity-hover: 0.2;
 
 // Transitions
 $profile-transition: all tokens.$sheet-transition-medium;
-$profile-hover-scale: 1.05;
+$profile-hover-scale: 1.03;
 
 // Opacity values
 $profile-disabled-opacity: tokens.$sheet-opacity-disabled;

--- a/src/scss/components/sheet/tables/_controls.scss
+++ b/src/scss/components/sheet/tables/_controls.scss
@@ -160,5 +160,6 @@
     display: inline-flex;
     align-items: center;
     gap: $erps-table-gap-small;
+    padding-right: $erps-table-gap-small;
   }
 }

--- a/src/scss/global/_eventide-sheet.scss
+++ b/src/scss/global/_eventide-sheet.scss
@@ -1,6 +1,7 @@
 @use "../utils/colors" as colors;
 @use "../utils/typography" as typography;
 @use "../utils/themes" as themes;
+@use "../utils/sheet-tokens" as tokens;
 @use "../components/sheet/resource-boxes" as resource-boxes;
 @use "../components/sheet/erps-profile-images" as profile-images;
 @use "sass:map";
@@ -200,6 +201,7 @@ label,
         flex-shrink: 0;
         position: relative;
         z-index: 2;
+        margin: tokens.$sheet-spacing-xs;
       }
 
       .eventide-sheet__header-fields {
@@ -228,6 +230,11 @@ label,
       padding: 0.2rem;
       margin-bottom: 0.5rem;
       position: relative;
+
+      // Give the profile image grid cell breathing room so hover glow doesn't clip
+      .flexcol.grid-span-2 {
+        padding: tokens.$sheet-spacing-xs;
+      }
 
       // Add subtle animated glow using theme colors
       &::before {


### PR DESCRIPTION
- Reduce profile hover scale from 1.05 to 1.03 to minimize overflow
- Add 4px padding to actor header image grid cell for breathing room
- Add 4px margin to item header profile image for glow space
- Add 8px right padding to create-buttons container so +Template button isn't flush against the table cell edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the hover animation effect for profile images to be more subtle.
  * Adjusted spacing and padding across various UI elements for improved visual layout and prevent visual clipping on hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->