### PR TITLE
 Fix: always create chat cards for status application/removal regardless of description

### DIFF
--- a/module/services/hooks/chat-listeners.mjs
+++ b/module/services/hooks/chat-listeners.mjs
@@ -258,7 +258,7 @@ function setupItemCreationHooks() {
     if (game.user.id !== triggerPlayer) return;
 
     // Handle status message creation
-    if (item.type === "status" && item.system.description) {
+    if (item.type === "status") {
       erps.messages.createStatusMessage(
         item,
         item.flags?.["eventide-rp-system"]?.isEffect
@@ -306,7 +306,7 @@ function setupItemDeletionHooks() {
     if (game.user.id !== triggerPlayer) return;
 
     // Handle status removal message
-    if (item.type === "status" && item.system.description) {
+    if (item.type === "status") {
       erps.messages.createDeleteStatusMessage(item);
     }
   });


### PR DESCRIPTION
Removed the item.system.description guard from the createItem and deleteItem hooks for status-type items. Status effects now always produce a chat card when applied or removed, even when they have no description or effects set.

The underlying createStatusMessage and createDeleteStatusMessage services already handle empty descriptions gracefully — they pass an empty string to the template, which conditionally hides the description section while still rendering the full chat card.