### PR TITLE
fix: v14.10.0 review findings from PR #222

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm run test:ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false

--- a/module/services/managers/roll-dice.mjs
+++ b/module/services/managers/roll-dice.mjs
@@ -373,13 +373,14 @@ class ERPSRollHandler {
 
     // Render template and create a single chat message with both rolls
     const content = await renderTemplate(this.templates.standard, templateData);
+    const primaryRoll = resolveSection?.roll ?? powerSection?.roll;
     const messageData = await this._createMessageData({
       speaker: ChatMessage.getSpeaker({ actor }),
       content,
       rolls,
       type: primaryType,
-      formula: "",
-      total: 0,
+      formula: primaryRoll?.formula ?? "",
+      total: primaryRoll?.total ?? 0,
       rollMode: "roll",
     });
     await ChatMessage.create(messageData);
@@ -402,9 +403,10 @@ class ERPSRollHandler {
    */
   _computeOverhealing(total, resource) {
     if (!resource) return null;
-    const room = resource.override
-      ? resource.override - resource.value
-      : resource.max - resource.value;
+    const room =
+      resource.override != null
+        ? resource.override - resource.value
+        : resource.max - resource.value;
     if (total > room) {
       return total - room;
     }

--- a/tests/setup.mjs
+++ b/tests/setup.mjs
@@ -42,15 +42,16 @@ if (!global.foundry.applications.handlebars) {
   };
 }
 
+// Ensure canvas has tokens property (library mock omits it)
+if (global.canvas && !global.canvas.tokens) {
+  global.canvas.tokens = { placeables: [] };
+}
+
 // Ensure CONFIG.EVENTIDE_RP_SYSTEM has baseline ability configuration.
 // Individual tests may override with more specific values.
 if (!global.CONFIG) global.CONFIG = {};
 if (!global.CONFIG.EVENTIDE_RP_SYSTEM) {
-
-// Ensure canvas has tokens property (library mock omits it)
-if (global.canvas && !global.canvas.tokens) {
-  global.canvas.tokens = { placeables: [] };
-}  global.CONFIG.EVENTIDE_RP_SYSTEM = {
+  global.CONFIG.EVENTIDE_RP_SYSTEM = {
     abilities: {
       acro: 'EVENTIDE_RP_SYSTEM.Abilities.Acro',
       phys: 'EVENTIDE_RP_SYSTEM.Abilities.Phys',
@@ -330,7 +331,7 @@ global.foundry.utils.getDocumentClass = function getDocumentClass(
   if (documentName && global.CONFIG?.[documentName]?.documentClass) {
     return global.CONFIG[documentName].documentClass;
   }
-  return global.CONFIG?.Item?.documentClass || class {};
+  return class {};
 };
 
 global.foundry.utils.isNewerVersion = function isNewerVersion(v1, v2) {
@@ -583,8 +584,10 @@ globalThis.Roll = class EnhancedMockRoll {
     );
 
     // Resolve dice terms (NdM) deterministically: each die rolls its minimum (1)
-    formula = formula.replace(/(\d+)d(\d+)([khlo!]*)/gi, (match, count) =>
-      String(parseInt(count, 10)),
+    // Consume the full modifier suffix (kh1, kl2, etc.) so no trailing chars remain
+    formula = formula.replace(
+      /(\d+)d(\d+)(?:[khlo!]\d*)*/gi,
+      (match, count) => String(parseInt(count, 10)),
     );
 
     // Map Foundry/math helper functions to their JS Math equivalents

--- a/tests/unit/documents/mixins/item-action-card-execution.test.mjs
+++ b/tests/unit/documents/mixins/item-action-card-execution.test.mjs
@@ -1608,7 +1608,7 @@ describe('ItemActionCardExecutionMixin', () => {
         new Error('Damage failed'),
       );
 
-      // Should not throw, just propagate the error
+      // The processor error propagates and the promise rejects
       await expect(item.executeSavedDamage({})).rejects.toThrow('Damage failed');
     });
   });


### PR DESCRIPTION
## Review Fixes for v14.10.0

Addresses findings from the PR #222 (develop → main) code review.

### Fixed (7 issues)

| # | Finding | Fix |
|---|---------|-----|
| 1 | **`_computeOverhealing` override=0 bug** | Changed truthiness check (`resource.override ?`) to explicit null check (`resource.override != null ?`) so a valid override of 0 is respected |
| 2 | **`handleDamageBundle` metadata** | Pass actual formula and total from primary roll to `_createMessageData` instead of empty string and zero |
| 3 | **`canvas.tokens` mock position** | Moved outside the `CONFIG.EVENTIDE_RP_SYSTEM` guard so it always backfills regardless of CONFIG state |
| 4 | **`getDocumentClass` fallback** | Removed `CONFIG.Item.documentClass` fallback for non-Item document types — returns generic class instead |
| 5 | **Dice normalization suffix** | Regex now consumes full modifier+count suffix (`kh1`, `kl2`, etc.) so `4d6kh3` leaves no trailing characters |
| 6 | **Stale test comment** | "Should not throw" → "error propagates and the promise rejects" |
| 7 | **Codecov action** | Bumped `codecov-action@v4` → `@v5` |

### Skipped (with reasons)

- **ErrorHandler for validation**: Synchronous validation uses raw throw, consistent with sibling `damageResolve` method
- **`_currentDamageGates` refactor**: Sequential `await` prevents concurrent overwrites; try/finally cleanup already added
- **`isZeroFormula` in repetition-handler**: Adds cross-service coupling for marginal edge-case benefit
- **Extract formula validator / resource delta / `_buildDamageSection`**: Pure refactoring with no bug fixes

### Test Results
```
Test Files  78 passed (78)
     Tests  3385 passed | 4 skipped (3389)
```