### PR TITLE
fix: always run transformations in saved damage, extract _computeDamageGates

### DIFF
--- a/module/documents/mixins/item-action-card-execution.mjs
+++ b/module/documents/mixins/item-action-card-execution.mjs
@@ -1011,6 +1011,24 @@ export function ItemActionCardExecutionMixin(Base) {
     }
 
     /**
+     * Compute per-damage-type gates for a given repetition index.
+     * Each type applies on the first repetition (index 0) regardless of its
+     * per-success toggle; on subsequent repetitions it applies only if the
+     * toggle is enabled.
+     * @param {number} repetitionIndex - Current repetition index (0-based)
+     * @returns {{ applyResolve: boolean, applyPower: boolean }}
+     * @private
+     */
+    _computeDamageGates(repetitionIndex) {
+      return {
+        applyResolve:
+          this.system.damageApplication || repetitionIndex === 0,
+        applyPower:
+          this.system.powerDamageApplication || repetitionIndex === 0,
+      };
+    }
+
+    /**
      * Execute a single attack chain iteration with repetition awareness
      * @param {Actor} actor - The actor executing the action card
      * @param {Roll} rollResult - The roll result for this iteration
@@ -1025,10 +1043,8 @@ export function ItemActionCardExecutionMixin(Base) {
       totalRepetitions,
     ) {
       // Determine if each damage type should apply based on its toggle and repetition index
-      const applyResolve =
-        this.system.damageApplication || repetitionIndex === 0;
-      const applyPower =
-        this.system.powerDamageApplication || repetitionIndex === 0;
+      const { applyResolve, applyPower } =
+        this._computeDamageGates(repetitionIndex);
       // Damage processing happens if either type should apply
       const shouldApplyDamage = applyResolve || applyPower;
       const damageGates = { applyResolve, applyPower };
@@ -1079,25 +1095,12 @@ export function ItemActionCardExecutionMixin(Base) {
       repetitionIndex,
       totalRepetitions,
     ) {
-      // Determine if each damage type should apply based on its toggle and repetition index
-      const applyResolve =
-        this.system.damageApplication || repetitionIndex === 0;
-      const applyPower =
-        this.system.powerDamageApplication || repetitionIndex === 0;
+      const { applyResolve, applyPower } =
+        this._computeDamageGates(repetitionIndex);
 
-      // Skip entirely only if neither damage type should apply
-      if (!applyResolve && !applyPower) {
-        return {
-          success: true,
-          mode: "savedDamage",
-          repetitionIndex,
-          totalRepetitions,
-          damageResults: [],
-          skipped: true,
-        };
-      }
-
-      // Reuse existing executeSavedDamage logic, passing the per-type gates
+      // Always call executeSavedDamage so embedded transformations run even
+      // when both damage types are gated off. The damage processor skips
+      // damage naturally when both gates are false.
       const result = await this.executeSavedDamage(actor, {
         applyResolve,
         applyPower,

--- a/tests/unit/documents/mixins/item-action-card-execution.test.mjs
+++ b/tests/unit/documents/mixins/item-action-card-execution.test.mjs
@@ -1754,18 +1754,22 @@ describe('ItemActionCardExecutionMixin', () => {
   });
 
   describe('executeSavedDamageIteration()', () => {
-    test('should skip execution when repetitionIndex > 0 and damageApplication is false', async () => {
+    test('should still call executeSavedDamage when both damage gates are off', async () => {
       item.system.damageApplication = false;
-      item.system.savedDamage = { formula: '2d6', type: 'damage' };
-      
+      item.system.powerDamageApplication = false;
+      item.system.savedDamage = { formula: '2d6', type: 'damage', powerFormula: '0', powerType: 'damage' };
+
       mockTargetResolver.resolveTargets.mockResolvedValue({
         success: true,
         targets: []
       });
-      
+
+      mockDamageProcessor.processSavedDamage.mockResolvedValue([]);
+
       const result = await item.executeSavedDamageIteration({}, 1, 2);
-      
-      expect(result.skipped).toBe(true);
+
+      // executeSavedDamage runs (for transformations etc.) but damage is empty
+      expect(result.success).toBe(true);
       expect(result.damageResults).toEqual([]);
     });
 


### PR DESCRIPTION
## Changes

### 1. Fix: Remove early return that skipped transformations (Outside diff)

**Bug**: `executeSavedDamageIteration` had an early return when both `applyResolve` and `applyPower` were false. This skipped calling `executeSavedDamage` entirely, which meant **embedded transformations were not processed** on repetitions where both damage types were gated off.

**Fix**: Remove the early return. Always call `executeSavedDamage` with the per-type gates. The damage processor naturally skips damage when both gates are false (no targets qualify), but transformations still run.

### 2. Nitpick: Extract `_computeDamageGates` helper

Eliminated duplicated toggle+repetition-index calculations between `executeAttackChainIteration` and `executeSavedDamageIteration` by extracting a shared `_computeDamageGates(repetitionIndex)` method.

### Test Results
```
Test Files  78 passed (78)
     Tests  3385 passed | 4 skipped (3389)
```