### PR TITLE
fix: route applyDamageBundle errors through ErrorHandler

### DIFF
--- a/module/documents/mixins/actor-resources.mjs
+++ b/module/documents/mixins/actor-resources.mjs
@@ -330,7 +330,10 @@ export const ActorResourceMixin = (BaseClass) =>
         });
         return { resolveRoll, powerRoll };
       } catch (error) {
-        Logger.error("Error in damage bundle operation", error, "RESOURCES");
+        await ErrorHandler.handleAsync(Promise.reject(error), {
+          context: "Damage bundle operation",
+          errorType: ErrorHandler.ERROR_TYPES.FOUNDRY_API,
+        });
         Logger.methodExit("ActorResourceMixin", "applyDamageBundle", null);
         throw error;
       }


### PR DESCRIPTION
## Change

Replaces the raw `Logger.error` + `throw` in `applyDamageBundle`'s catch block with `ErrorHandler.handleAsync`, following the existing pattern at line 472 in the same file.

Errors (including validation errors for invalid damage types) now flow through the centralized `ErrorHandler` for consistent logging and user notification before being re-thrown to callers.

```js
// Before:
} catch (error) {
  Logger.error("Error in damage bundle operation", error, "RESOURCES");
  Logger.methodExit("ActorResourceMixin", "applyDamageBundle", null);
  throw error;
}

// After:
} catch (error) {
  await ErrorHandler.handleAsync(Promise.reject(error), {
    context: "Damage bundle operation",
    errorType: ErrorHandler.ERROR_TYPES.FOUNDRY_API,
  });
  Logger.methodExit("ActorResourceMixin", "applyDamageBundle", null);
  throw error;
}
```

### Test Results
```
Test Files  78 passed (78)
     Tests  3385 passed | 4 skipped (3389)
```